### PR TITLE
Merge ucrt_fix into master

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -83,3 +83,6 @@
 ^man/figures$
 ^errors.txt$
 ^gdalcubes.log$
+^.bash_history$
+^.vscode$
+^README.html$

--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ proj_conf_test.c
 docs
 errors.txt
 gdalcubes.log
+.bash_history
+.vscode
+README.html

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -56,7 +56,7 @@ URL: https://github.com/appelmar/gdalcubes
 BugReports: https://github.com/appelmar/gdalcubes/issues/
 Encoding: UTF-8
 RoxygenNote: 7.2.2
-LinkingTo: Rcpp
+LinkingTo: Rcpp, BH
 Suggests: 
     knitr,
     magrittr,

--- a/R/image_collection.R
+++ b/R/image_collection.R
@@ -301,7 +301,7 @@ collection_formats <-function(print=TRUE)
 #' @examples 
 #' \donttest{
 #' add_collection_format(
-#'    "https://raw.githubusercontent.com/appelmar/gdalcubes/dev/formats/Sentinel1_IW_GRD.json")
+#'    "https://raw.githubusercontent.com/appelmar/gdalcubes_cpp/dev/formats/Sentinel1_IW_GRD.json")
 #' }
 #' @export
 add_collection_format <- function(url, name=NULL) {

--- a/man/add_collection_format.Rd
+++ b/man/add_collection_format.Rd
@@ -20,6 +20,6 @@ By default, the collection format name will be derived from the basename of the 
 \examples{
 \donttest{
 add_collection_format(
-   "https://raw.githubusercontent.com/appelmar/gdalcubes/dev/formats/Sentinel1_IW_GRD.json")
+   "https://raw.githubusercontent.com/appelmar/gdalcubes_cpp/dev/formats/Sentinel1_IW_GRD.json")
 }
 }

--- a/src/gdalcubes/src/datetime.h
+++ b/src/gdalcubes/src/datetime.h
@@ -38,7 +38,6 @@
 
 #include <chrono>
 #include <iomanip>
-#include <regex>
 #include <cstdint> // 2023-01-12: GCC 13 compatibility
 #include "error.h"
 #include "external/date.h"

--- a/src/multiprocess.cpp
+++ b/src/multiprocess.cpp
@@ -110,17 +110,14 @@ void chunk_processor_multiprocess::apply(std::shared_ptr<cube> c,
       
       // Consider files with name X.nc, where X is an integer number
       // Temporary files will start with a dot and are NOT considered here
-      std::regex r("^([0-9]+)\\.nc$");
-      std::smatch match;
       std::string basename  = filesystem::stem(f) + "." + filesystem::extension(f);
-      if (std::regex_search(basename, match, r)) {
-        if (match.size() == 2) {
-          try {
-            int chunkid = std::stoi(match[1].str());
+      std::size_t pos = basename.find(".nc");
+      if (pos > 0 && pos < std::string::npos) {
+        try {
+            int chunkid = std::stoi(basename.substr(0,pos));
             chunk_queue.push_back(std::make_pair<>(f, chunkid));
           }
           catch (...) {}
-        }
       }
     });
   


### PR DESCRIPTION
This fix will avoid the use of std::regex where possible and use boost::regex instead when needed. This fixes windows compatibility with the new ucrt toolchain.