### PR TITLE
Use pkg-config on Windows when available.

### DIFF
--- a/src/Makevars.ucrt
+++ b/src/Makevars.ucrt
@@ -50,7 +50,8 @@ PKG_CPPFLAGS = \
 
 LIBSHARPYUV = $(or $(and $(wildcard $(R_TOOLS_SOFT)/lib/libsharpyuv.a),-lsharpyuv),)
 
-PKG_LIBS = \
+ifeq (,$(shell pkg-config --version 2>/dev/null))
+  PKG_LIBS = \
   -fopenmp -lgdal -larmadillo -lopenblas -lgfortran -lquadmath -lpq -lpgcommon -lpgport -lodbc32 \
   -lodbccp32 -lblosc -lkea -lhdf5_cpp -lhdf5 -lpoppler -llcms2 -lfreetype -lharfbuzz -lfreetype -llz4 \
   -lpcre2-8 -lxml2 -lopenjp2 -lnetcdf -lmysqlclient -lspatialite -lgeos_c -lgeos -lminizip -lgeos \
@@ -59,7 +60,9 @@ PKG_LIBS = \
   -lcurl -lbcrypt -lrtmp -lssl -lssh2 -lidn2 -lunistring -liconv -lgcrypt -lcrypto -lgpg-error \
   -lws2_32 -ltiff -llzma -ljpeg -lz -lcfitsio -lzstd -lwebpdecoder -lwebp $(LIBSHARPYUV) -lsbml-static -lgeotiff \
   -lproj -lsqlite3 -lbz2 -lcrypt32 -lwldap32 -lsecur32
-
+else
+  PKG_LIBS = $(shell pkg-config --libs netcdf sqlite3 gdal)
+endif
 
 all: clean winlibs
 


### PR DESCRIPTION
This will use pkg-config to establish the libraries to link when pkg-config is available (which will soon be in Rtools). This should reduce the frequency of needed updates to linking when new features are linked/enabled in gdal.