### PR TITLE
Remove whitespace after operator""

### DIFF
--- a/src/gdalcubes/src/external/date.h
+++ b/src/gdalcubes/src/external/date.h
@@ -910,8 +910,8 @@ namespace date {
 
 #if !defined(_MSC_VER) || (_MSC_VER >= 1900)
     inline namespace literals {
-        CONSTCD11 date::day operator"" _d(unsigned long long d) NOEXCEPT;
-        CONSTCD11 date::year operator"" _y(unsigned long long y) NOEXCEPT;
+        CONSTCD11 date::day operator""_d(unsigned long long d) NOEXCEPT;
+        CONSTCD11 date::year operator""_y(unsigned long long y) NOEXCEPT;
 
     }   // namespace literals
 #endif  // !defined(_MSC_VER) || (_MSC_VER >= 1900)
@@ -1702,13 +1702,13 @@ namespace date {
     inline namespace literals {
         CONSTCD11
         inline date::day
-        operator"" _d(unsigned long long d) NOEXCEPT {
+        operator""_d(unsigned long long d) NOEXCEPT {
             return date::day{static_cast<unsigned>(d)};
         }
 
         CONSTCD11
         inline date::year
-        operator"" _y(unsigned long long y) NOEXCEPT {
+        operator""_y(unsigned long long y) NOEXCEPT {
             return date::year(static_cast<int>(y));
         }
 #endif  // !defined(_MSC_VER) || (_MSC_VER >= 1900)


### PR DESCRIPTION
The space after `""` is deprecated since it creates ambiguity with reserved `_`-initial names per:

https://en.cppreference.com/w/cpp/language/user_literal

This might start throwing compiler warnings under `clang++-20`.