### PR TITLE
Fix segfault when computing filter_geom() cubes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# gdalcubes 0.7.5 (unreleased)
+
+* fix segfault in worker processes when computing a `filter_geom()` cube under GDAL 3 (#110)
+
 # gdalcubes 0.7.4 (2026-05-28)
 
 * fix GCC16 issues on CRAN

--- a/inst/tinytest/test_filter_geom.R
+++ b/inst/tinytest/test_filter_geom.R
@@ -1,0 +1,30 @@
+library(gdalcubes)
+
+# regression test for a segfault when computing a filter_geom() cube
+# (https://github.com/appelmar/gdalcubes/issues/110)
+
+v = cube_view(srs = "EPSG:32610",
+              extent = list(left = 500000, right = 502000, bottom = 6000000, top = 6002000,
+                            t0 = "2020-01-01", t1 = "2020-01-01"),
+              dx = 10, dy = 10, dt = "P1D")
+
+wkt = "POLYGON((500500 6000500, 501500 6000500, 501500 6001500, 500500 6001500, 500500 6000500))"
+
+gdalcubes:::.raster_cube_dummy(v, 1, 1.0) |>
+  filter_geom(wkt, srs = "EPSG:32610") -> cube
+expect_equal(dim(cube), c(1, 200, 200))
+
+x = as_array(cube)  # dimensions: band, t, y, x
+expect_equal(dim(x), c(1, 1, 200, 200))
+expect_equal(sum(!is.na(x)), 10000)     # 100x100 cells inside the polygon
+expect_true(all(x[!is.na(x)] == 1))
+expect_equal(x[1, 1, 100, 100], 1)      # centre of the polygon
+expect_true(is.na(x[1, 1, 10, 10]))     # corners are outside
+expect_true(is.na(x[1, 1, 190, 190]))
+
+# with small chunks, chunks completely inside the polygon take a copy fast path;
+# the mask must be identical regardless of chunk layout
+gdalcubes:::.raster_cube_dummy(v, 1, 1.0, chunking = c(1, 50, 50)) |>
+  filter_geom(wkt, srs = "EPSG:32610") -> cube_chunked
+y = as_array(cube_chunked)
+expect_equal(is.na(x), is.na(y))

--- a/src/gdalcubes/src/filter_geom.cpp
+++ b/src/gdalcubes/src/filter_geom.cpp
@@ -124,6 +124,10 @@ filter_geom_cube::filter_geom_cube(std::shared_ptr<cube> in, std::string wkt, st
     std::string output_file = "/vsimem/" + utils::generate_unique_filename(8, "crop_", ".gpkg");
     _ogr_dataset = output_file;
     GDALDriver *gpkg_driver = GetGDALDriverManager()->GetDriverByName("GPKG");
+    if (gpkg_driver == NULL) {
+        GCBS_ERROR("GPKG driver is not available");
+        throw std::string("GPKG driver is not available");
+    }
     GDALDataset *gpkg_out = gpkg_driver->Create(output_file.c_str(), 0, 0, 0, GDT_Unknown, NULL);
     if (gpkg_out == NULL) {
         GCBS_ERROR("Creation of GPKG file '" + output_file + "' failed");
@@ -182,7 +186,6 @@ std::shared_ptr<chunk_data> filter_geom_cube::read_chunk(chunkid_t id) {
     OGRPolygon pp;
     OGRLinearRing a;
     bounds_2d<double> sextent = bounds_from_chunk(id).s;
-    OGRSpatialReference srs_cube = st_reference()->srs_ogr();
 
     a.addPoint(sextent.left, sextent.bottom);
     a.addPoint(sextent.right, sextent.bottom);
@@ -190,13 +193,20 @@ std::shared_ptr<chunk_data> filter_geom_cube::read_chunk(chunkid_t id) {
     a.addPoint(sextent.left, sextent.top);
     a.addPoint(sextent.left, sextent.bottom);
     pp.addRing(&a);
-    pp.assignSpatialReference(&srs_cube);
+    // no SRS is assigned to pp: assignSpatialReference() takes refcounted ownership
+    // and ~OGRGeometry() calls Release() on it, which crashes for stack-allocated
+    // SRS objects; Contains() / Intersects() below do not use the SRS anyway
 
     // iterate over all features
     bool chunk_within_polygon = false;
     bool outside = false;
     layer->ResetReading();
     OGRFeature *cur_feature = layer->GetNextFeature();  // assumption, there is only one feature
+    if (cur_feature == NULL) {
+        GDALClose(in_ogr_dataset);
+        GCBS_ERROR("no feature found in '" + _ogr_dataset + "'");
+        throw std::string("no feature found in '" + _ogr_dataset + "'");
+    }
     OGRGeometry *geom = cur_feature->GetGeometryRef();
     if (geom != NULL) {
         if (geom->Contains(&pp)) {
@@ -276,15 +286,20 @@ std::shared_ptr<chunk_data> filter_geom_cube::read_chunk(chunkid_t id) {
         }
         int err = 0;
         GDALDataset *gdal_rasterized = (GDALDataset *)GDALRasterize("", NULL, (GDALDatasetH)in_ogr_dataset, rasterize_opts, &err);
-        if (gdal_rasterized == NULL) {
-            GCBS_ERROR("gdal_rasterize failed ");
-        }
-
         GDALRasterizeOptionsFree(rasterize_opts);
+        if (gdal_rasterized == NULL) {
+            GDALClose(in_ogr_dataset);
+            GCBS_ERROR("gdal_rasterize failed");
+            throw std::string("ERROR in filter_geom_cube::read_chunk(): gdal_rasterize failed");
+        }
 
         uint8_t *geom_mask = (uint8_t *)std::malloc(sizeof(uint8_t) * in->size()[3] * in->size()[2]);
         if (gdal_rasterized->GetRasterBand(1)->RasterIO(GF_Read, 0, 0, in->size()[3], in->size()[2], geom_mask, in->size()[3], in->size()[2], GDT_Byte, 0, 0, NULL) != CE_None) {
+            std::free(geom_mask);
+            GDALClose(gdal_rasterized);
+            GDALClose(in_ogr_dataset);
             GCBS_ERROR("RasterIO failed");
+            throw std::string("ERROR in filter_geom_cube::read_chunk(): RasterIO failed");
         }
         for (uint32_t iy = 0; iy < in->size()[2]; ++iy) {
             for (uint32_t ix = 0; ix < in->size()[3]; ++ix) {


### PR DESCRIPTION
Thanks for gdalcubes — it's a genuinely well-crafted piece of software and foundational to a number of workflows we're developing. Work like this matters, and we appreciate it.

Fixes #110

`read_chunk()` in `filter_geom.cpp` assigned a stack-allocated `OGRSpatialReference` to the chunk polygon via `assignSpatialReference()`, which takes refcounted ownership — `~OGRGeometry()` later calls `Release()` on the already-destroyed stack object, so every computed `filter_geom()` cube crashed the worker process with SIGSEGV under GDAL 3. Fixed by dropping the assignment (`Contains()`/`Intersects()` don't use the SRS, and both geometries are already in the cube CRS). Also converted the log-and-continue error paths in the same file into proper errors (one was a second latent null dereference after a failed `GDALRasterize()`), and added a regression test — `filter_geom()` previously had none.

The reprex from #110 now runs clean (macOS arm64, R 4.5.2, GDAL 3.13.3):

```r
box <- st_sfc(st_polygon(list(rbind(
  c(500500, 6000500), c(501500, 6000500),
  c(501500, 6001500), c(500500, 6001500), c(500500, 6000500)))), crs = 32610)
write_ncdf(filter_geom(raster_cube(col, v), box), tempfile(fileext = ".nc"))
#> previously *** caught segfault *** — now writes the cube masked to the polygon
```

May also relate to #82, since the same code path runs in the Windows worker processes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
